### PR TITLE
Refactor Operator E2E test suite to compatible with OpenShift Cluster environment

### DIFF
--- a/infra/feast-operator/test/e2e/e2e_test.go
+++ b/infra/feast-operator/test/e2e/e2e_test.go
@@ -17,11 +17,16 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/feast-dev/feast/infra/feast-operator/test/utils"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("controller", Ordered, func() {
+	_, isRunOnOpenShiftCI := os.LookupEnv("RUN_ON_OPENSHIFT_CI")
 	featureStoreName := "simple-feast-setup"
 	feastResourceName := utils.FeastPrefix + featureStoreName
 	feastK8sResourceNames := []string{
@@ -29,26 +34,40 @@ var _ = Describe("controller", Ordered, func() {
 		feastResourceName + "-offline",
 		feastResourceName + "-ui",
 	}
+	namespace := "test-ns-feast"
+	defaultFeatureStoreCRTest := "TesDefaultFeastCR"
+	remoteRegisteFeatureStoreCRTest := "TestRemoteRegistryFeastCR"
 
 	runTestDeploySimpleCRFunc := utils.GetTestDeploySimpleCRFunc("/test/e2e",
 		"test/testdata/feast_integration_test_crs/v1alpha1_default_featurestore.yaml",
-		featureStoreName, feastResourceName, feastK8sResourceNames)
+		featureStoreName, feastResourceName, feastK8sResourceNames, namespace)
 
 	runTestWithRemoteRegistryFunction := utils.GetTestWithRemoteRegistryFunc("/test/e2e",
 		"test/testdata/feast_integration_test_crs/v1alpha1_default_featurestore.yaml",
 		"test/testdata/feast_integration_test_crs/v1alpha1_remote_registry_featurestore.yaml",
-		featureStoreName, feastResourceName, feastK8sResourceNames)
+		featureStoreName, feastResourceName, feastK8sResourceNames, namespace)
 
 	BeforeAll(func() {
-		utils.DeployOperatorFromCode("/test/e2e", false)
+		if !isRunOnOpenShiftCI {
+			utils.DeployOperatorFromCode("/test/e2e", false)
+		}
+		By(fmt.Sprintf("Creating test namespace: %s", namespace))
+		err := utils.CreateNamespace(namespace, "/test/e2e")
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to create namespace %s", namespace))
 	})
 
 	AfterAll(func() {
-		utils.DeleteOperatorDeployment("/test/e2e")
+		if !isRunOnOpenShiftCI {
+			utils.DeleteOperatorDeployment("/test/e2e")
+		}
+		By(fmt.Sprintf("Deleting test namespace: %s", namespace))
+		err := utils.DeleteNamespace(namespace, "/test/e2e")
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to delete namespace %s", namespace))
+
 	})
 
 	Context("Operator E2E Tests", func() {
-		It("Should be able to deploy and run a default feature store CR successfully", runTestDeploySimpleCRFunc)
-		It("Should be able to deploy and run a feature store with remote registry CR successfully", runTestWithRemoteRegistryFunction)
+		It("Should be able to deploy and run a "+defaultFeatureStoreCRTest+" successfully", runTestDeploySimpleCRFunc)
+		It("Should be able to deploy and run a "+remoteRegisteFeatureStoreCRTest+"  successfully", runTestWithRemoteRegistryFunction)
 	})
 })

--- a/infra/feast-operator/test/previous-version/previous_version_test.go
+++ b/infra/feast-operator/test/previous-version/previous_version_test.go
@@ -38,9 +38,9 @@ var _ = Describe("previous version operator", Ordered, func() {
 		}
 
 		runTestDeploySimpleCRFunc := utils.GetTestDeploySimpleCRFunc("/test/upgrade", utils.GetSimplePreviousVerCR(),
-			utils.FeatureStoreName, utils.FeastResourceName, feastK8sResourceNames)
+			utils.FeatureStoreName, utils.FeastResourceName, feastK8sResourceNames, "default")
 		runTestWithRemoteRegistryFunction := utils.GetTestWithRemoteRegistryFunc("/test/upgrade", utils.GetSimplePreviousVerCR(),
-			utils.GetRemoteRegistryPreviousVerCR(), utils.FeatureStoreName, utils.FeastResourceName, feastK8sResourceNames)
+			utils.GetRemoteRegistryPreviousVerCR(), utils.FeatureStoreName, utils.FeastResourceName, feastK8sResourceNames, "default")
 
 		// Run Test on previous version operator
 		It("Should be able to deploy and run a default feature store CR successfully", runTestDeploySimpleCRFunc)

--- a/infra/feast-operator/test/testdata/feast_integration_test_crs/v1alpha1_remote_registry_featurestore.yaml
+++ b/infra/feast-operator/test/testdata/feast_integration_test_crs/v1alpha1_remote_registry_featurestore.yaml
@@ -12,4 +12,4 @@ spec:
       remote:
         feastRef:
           name: simple-feast-setup
-          namespace: default
+          namespace: test-ns-feast

--- a/infra/feast-operator/test/upgrade/upgrade_test.go
+++ b/infra/feast-operator/test/upgrade/upgrade_test.go
@@ -33,9 +33,9 @@ var _ = Describe("operator upgrade", Ordered, func() {
 
 	Context("Operator upgrade Tests", func() {
 		runTestDeploySimpleCRFunc := utils.GetTestDeploySimpleCRFunc("/test/upgrade", utils.GetSimplePreviousVerCR(),
-			utils.FeatureStoreName, utils.FeastResourceName, []string{})
+			utils.FeatureStoreName, utils.FeastResourceName, []string{}, "default")
 		runTestWithRemoteRegistryFunction := utils.GetTestWithRemoteRegistryFunc("/test/upgrade", utils.GetSimplePreviousVerCR(),
-			utils.GetRemoteRegistryPreviousVerCR(), utils.FeatureStoreName, utils.FeastResourceName, []string{})
+			utils.GetRemoteRegistryPreviousVerCR(), utils.FeatureStoreName, utils.FeastResourceName, []string{}, "default")
 
 		// Run Test on current version operator with previous version CR
 		It("Should be able to deploy and run a default feature store CR successfully", runTestDeploySimpleCRFunc)


### PR DESCRIPTION
closes https://issues.redhat.com/browse/RHOAIENG-23656

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
- Refactored the Operator E2E test suite for compatibility with OpenShift clusters, enabling test execution against RHOAI downstream builds.

- Standardized resource handling to consistently use dedicated test namespaces, and ensured proper cleanup of all created resources.

- Updated test names TestDefaultFeastCR and TestRemoteRegistryFeastCR to use It nodes, allowing targeted test execution via -ginkgo.focus.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://issues.redhat.com/browse/RHOAIENG-23656


