### PR TITLE
fix: Harden informer cache with label selectors and memory optimizations

### DIFF
--- a/infra/feast-operator/cmd/main.go
+++ b/infra/feast-operator/cmd/main.go
@@ -29,16 +29,23 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -67,6 +74,29 @@ func init() {
 	utilruntime.Must(feastdevv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(feastdevv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
+}
+
+func newCacheOptions() cache.Options {
+	managedBySelector := labels.SelectorFromSet(labels.Set{
+		services.ManagedByLabelKey: services.ManagedByLabelValue,
+	})
+	managedByFilter := cache.ByObject{Label: managedBySelector}
+
+	return cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.ConfigMap{}:                      managedByFilter,
+			&appsv1.Deployment{}:                     managedByFilter,
+			&corev1.Service{}:                        managedByFilter,
+			&corev1.ServiceAccount{}:                 managedByFilter,
+			&corev1.PersistentVolumeClaim{}:          managedByFilter,
+			&rbacv1.RoleBinding{}:                    managedByFilter,
+			&rbacv1.Role{}:                           managedByFilter,
+			&batchv1.CronJob{}:                       managedByFilter,
+			&autoscalingv2.HorizontalPodAutoscaler{}: managedByFilter,
+			&policyv1.PodDisruptionBudget{}:          managedByFilter,
+		},
+	}
 }
 
 func main() {
@@ -155,6 +185,7 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Cache: newCacheOptions(),
 		Client: client.Options{
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{

--- a/infra/feast-operator/config/default/related_image_fs_patch.tmpl
+++ b/infra/feast-operator/config/default/related_image_fs_patch.tmpl
@@ -1,10 +1,16 @@
+- op: test
+  path: "/spec/template/spec/containers/0/env/1/name"
+  value: RELATED_IMAGE_FEATURE_SERVER
 - op: replace
-  path: "/spec/template/spec/containers/0/env/0"
+  path: "/spec/template/spec/containers/0/env/1"
   value:
     name: RELATED_IMAGE_FEATURE_SERVER
     value: ${FS_IMG}
+- op: test
+  path: "/spec/template/spec/containers/0/env/2/name"
+  value: RELATED_IMAGE_CRON_JOB
 - op: replace
-  path: "/spec/template/spec/containers/0/env/1"
+  path: "/spec/template/spec/containers/0/env/2"
   value:
     name: RELATED_IMAGE_CRON_JOB
     value: ${CJ_IMG}

--- a/infra/feast-operator/config/default/related_image_fs_patch.yaml
+++ b/infra/feast-operator/config/default/related_image_fs_patch.yaml
@@ -1,10 +1,16 @@
+- op: test
+  path: "/spec/template/spec/containers/0/env/1/name"
+  value: RELATED_IMAGE_FEATURE_SERVER
 - op: replace
-  path: "/spec/template/spec/containers/0/env/0"
+  path: "/spec/template/spec/containers/0/env/1"
   value:
     name: RELATED_IMAGE_FEATURE_SERVER
     value: quay.io/feastdev/feature-server:0.61.0
+- op: test
+  path: "/spec/template/spec/containers/0/env/2/name"
+  value: RELATED_IMAGE_CRON_JOB
 - op: replace
-  path: "/spec/template/spec/containers/0/env/1"
+  path: "/spec/template/spec/containers/0/env/2"
   value:
     name: RELATED_IMAGE_CRON_JOB
     value: quay.io/openshift/origin-cli:4.17

--- a/infra/feast-operator/config/manager/manager.yaml
+++ b/infra/feast-operator/config/manager/manager.yaml
@@ -73,6 +73,8 @@ spec:
             drop:
             - "ALL"
         env:
+        - name: GOMEMLIMIT
+          value: "230MiB"
         - name: RELATED_IMAGE_FEATURE_SERVER
           value: feast:latest
         - name: RELATED_IMAGE_CRON_JOB

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -20595,6 +20595,8 @@ spec:
         command:
         - /manager
         env:
+        - name: GOMEMLIMIT
+          value: 230MiB
         - name: RELATED_IMAGE_FEATURE_SERVER
           value: quay.io/feastdev/feature-server:0.61.0
         - name: RELATED_IMAGE_CRON_JOB

--- a/infra/feast-operator/internal/controller/notebook_configmap_controller.go
+++ b/infra/feast-operator/internal/controller/notebook_configmap_controller.go
@@ -214,7 +214,7 @@ func (r *NotebookConfigMapReconciler) setNotebookConfigMapData(
 	if cm.Labels == nil {
 		cm.Labels = make(map[string]string)
 	}
-	cm.Labels["managed-by"] = "feast-operator"
+	cm.Labels[services.ManagedByLabelKey] = services.ManagedByLabelValue
 	cm.Labels["source-resource"] = notebook.GetName()
 	cm.Labels["source-kind"] = notebook.GetObjectKind().GroupVersionKind().Kind
 

--- a/infra/feast-operator/internal/controller/notebook_configmap_controller_test.go
+++ b/infra/feast-operator/internal/controller/notebook_configmap_controller_test.go
@@ -381,7 +381,7 @@ var _ = Describe("NotebookConfigMap Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cm.Data).To(HaveKey(projectName))
 			Expect(cm.Data[projectName]).To(Equal(testYAMLContent))
-			Expect(cm.Labels["managed-by"]).To(Equal("feast-operator"))
+			Expect(cm.Labels[services.ManagedByLabelKey]).To(Equal(services.ManagedByLabelValue))
 			Expect(cm.Labels["source-resource"]).To(Equal(notebookName))
 			Expect(cm.Labels["source-kind"]).To(Equal("Notebook"))
 			Expect(cm.OwnerReferences).To(HaveLen(1))

--- a/infra/feast-operator/internal/controller/services/services.go
+++ b/infra/feast-operator/internal/controller/services/services.go
@@ -405,9 +405,10 @@ func (feast *FeastServices) setDeployment(deploy *appsv1.Deployment) error {
 	}
 
 	deploy.Labels = feast.getLabels()
+	selectorLabels := feast.getSelectorLabels()
 	deploy.Spec = appsv1.DeploymentSpec{
 		Replicas: replicas,
-		Selector: metav1.SetAsLabelSelector(deploy.GetLabels()),
+		Selector: metav1.SetAsLabelSelector(selectorLabels),
 		Strategy: feast.getDeploymentStrategy(),
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -814,7 +815,7 @@ func (feast *FeastServices) setService(svc *corev1.Service, feastType FeastServi
 	}
 
 	svc.Spec = corev1.ServiceSpec{
-		Selector: feast.getLabels(),
+		Selector: feast.getSelectorLabels(),
 		Type:     corev1.ServiceTypeClusterIP,
 		Ports: []corev1.ServicePort{
 			{
@@ -972,7 +973,7 @@ func (feast *FeastServices) applyTopologySpread(podSpec *corev1.PodSpec) {
 		MaxSkew:           1,
 		TopologyKey:       "topology.kubernetes.io/zone",
 		WhenUnsatisfiable: corev1.ScheduleAnyway,
-		LabelSelector:     metav1.SetAsLabelSelector(feast.getLabels()),
+		LabelSelector:     metav1.SetAsLabelSelector(feast.getSelectorLabels()),
 	}}
 }
 
@@ -995,7 +996,7 @@ func (feast *FeastServices) applyAffinity(podSpec *corev1.PodSpec) {
 				Weight: 100,
 				PodAffinityTerm: corev1.PodAffinityTerm{
 					TopologyKey:   "kubernetes.io/hostname",
-					LabelSelector: metav1.SetAsLabelSelector(feast.getLabels()),
+					LabelSelector: metav1.SetAsLabelSelector(feast.getSelectorLabels()),
 				},
 			}},
 		},
@@ -1056,9 +1057,21 @@ func (feast *FeastServices) getFeastTypeLabels(feastType FeastServiceType) map[s
 	return labels
 }
 
-func (feast *FeastServices) getLabels() map[string]string {
+// getSelectorLabels returns the minimal label set used for immutable selectors
+// (Deployment spec.selector, Service spec.selector, TopologySpreadConstraints, PodAffinity).
+// This must NOT change after initial resource creation.
+func (feast *FeastServices) getSelectorLabels() map[string]string {
 	return map[string]string{
 		NameLabelKey: feast.Handler.FeatureStore.Name,
+	}
+}
+
+// getLabels returns the full label set for mutable metadata (ObjectMeta.Labels).
+// Includes the managed-by label used by the informer cache filter.
+func (feast *FeastServices) getLabels() map[string]string {
+	return map[string]string{
+		NameLabelKey:      feast.Handler.FeatureStore.Name,
+		ManagedByLabelKey: ManagedByLabelValue,
 	}
 }
 
@@ -1439,10 +1452,10 @@ func IsDeploymentAvailable(conditions []appsv1.DeploymentCondition) bool {
 // container that is in a failing state. Returns empty string if no failure found.
 func (feast *FeastServices) GetPodContainerFailureMessage(deploy appsv1.Deployment) string {
 	podList := corev1.PodList{}
-	labels := feast.getLabels()
+	selectorLabels := feast.getSelectorLabels()
 	if err := feast.Handler.Client.List(feast.Handler.Context, &podList,
 		client.InNamespace(deploy.Namespace),
-		client.MatchingLabels(labels),
+		client.MatchingLabels(selectorLabels),
 	); err != nil {
 		return ""
 	}

--- a/infra/feast-operator/internal/controller/services/services_types.go
+++ b/infra/feast-operator/internal/controller/services/services_types.go
@@ -95,6 +95,11 @@ const (
 	OidcMissingSecretError string = "missing OIDC secret: %s"
 )
 
+const (
+	ManagedByLabelKey   = "app.kubernetes.io/managed-by"
+	ManagedByLabelValue = "feast-operator"
+)
+
 var (
 	DefaultImage          = "quay.io/feastdev/feature-server:" + feastversion.FeastVersion
 	DefaultCronJobImage   = "quay.io/openshift/origin-cli:4.17"


### PR DESCRIPTION
## Summary

The feast-operator's `Owns()` calls create cluster-wide informers for ConfigMaps, Deployments, Services, and other resource types. On clusters with a large number of these objects, the informer cache can grow beyond the operator's 256Mi memory limit, causing OOMKill and restarts.

## Changes

### `ByObject` label selectors for all owned resource types

Restrict informer caches to only objects with `app.kubernetes.io/managed-by: feast-operator`. Covers all 10 owned types: ConfigMap, Deployment, Service, ServiceAccount, PVC, RoleBinding, Role, CronJob, HPA, PDB. Extracted into `newCacheOptions()` for clarity.

### `DefaultTransform: cache.TransformStripManagedFields()`

Strip `managedFields` from all cached objects, reducing per-object memory footprint by ~30-50%.

### `GOMEMLIMIT=230MiB`

Set Go runtime soft memory limit (90% of 256Mi container limit). Triggers GC pressure before hard OOMKill as defense-in-depth.

### Additional changes

- Add `app.kubernetes.io/managed-by: feast-operator` label to `getLabels()` so all FeatureStore-managed resources carry it
- Introduce `getSelectorLabels()` for immutable selectors (Deployment `spec.selector`, Service `spec.selector`, TopologySpreadConstraints, PodAffinity) to avoid breaking existing resources on upgrade
- Standardize notebook controller's managed-by label to `app.kubernetes.io/managed-by`
- Use shared constants (`services.ManagedByLabelKey`/`Value`) throughout

## Test Results

Verified on RHOAI 3.3.0 cluster with a large number of ConfigMaps pre-loaded:

| Metric | Before | After |
|--------|--------|-------|
| **Memory usage** | 254Mi (at limit) | **25Mi** |
| **Stability** | OOMKilled, CrashLoopBackOff | Stable, no restarts |

