### PR TITLE
feat: add Konflux build pipelines PR and nightly test workflow

### DIFF
--- a/.github/workflows/trigger-konflux-nightly.yaml
+++ b/.github/workflows/trigger-konflux-nightly.yaml
@@ -1,0 +1,96 @@
+name: Nightly Test Status Monitor
+
+# The Feast nightly integration test is scheduled and executed entirely within
+# Konflux via the PaC cron trigger in .tekton/feast-nightly-test.yaml (daily
+# at 8 AM UTC). The Konflux pipeline posts the result back to GitHub as a
+# commit status (context: konflux/nightly-feast) on the master HEAD.
+#
+# This workflow runs after the Konflux pipeline should have completed and
+# reports the nightly status in the GitHub Actions summary.
+#
+# No Konflux API secrets are required.
+
+on:
+  schedule:
+    - cron: '0 11 * * *'   # 11 AM UTC — Konflux nightly starts 8 AM, runs ~2h
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to check nightly status for'
+        required: false
+        default: 'master'
+        type: string
+
+env:
+  STATUS_CONTEXT: 'konflux/nightly-feast'
+
+jobs:
+  check-nightly-status:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: read
+    steps:
+      - name: Get branch HEAD SHA
+        id: sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ inputs.branch || 'master' }}
+        run: |
+          SHA=$(gh api "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" \
+            --jq '.object.sha')
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Branch: ${BRANCH}  SHA: ${SHA}"
+
+      - name: Read Konflux nightly commit status
+        id: nightly
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The Konflux nightly pipeline posts commit status via report-nightly-status task.
+          # Statuses are ordered newest-first; pick the first matching context.
+          PAYLOAD=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ steps.sha.outputs.sha }}/statuses" \
+            --jq "[.[] | select(.context == \"${STATUS_CONTEXT}\")] | first // {}")
+
+          STATE=$(echo "$PAYLOAD"       | jq -r '.state       // "not_found"')
+          DESCRIPTION=$(echo "$PAYLOAD" | jq -r '.description // ""')
+          TARGET_URL=$(echo "$PAYLOAD"  | jq -r '.target_url  // ""')
+
+          echo "state=${STATE}"             >> "$GITHUB_OUTPUT"
+          echo "description=${DESCRIPTION}" >> "$GITHUB_OUTPUT"
+          echo "target_url=${TARGET_URL}"   >> "$GITHUB_OUTPUT"
+
+          echo "Konflux nightly status: ${STATE}"
+          echo "Description:            ${DESCRIPTION}"
+          echo "Details URL:            ${TARGET_URL}"
+
+          if [ "${STATE}" = "pending" ]; then
+            echo "::warning::Konflux nightly pipeline is still pending — results not available yet."
+          elif [ "${STATE}" = "not_found" ]; then
+            echo "::warning::No commit status found for context '${STATUS_CONTEXT}' on ${BRANCH} HEAD."
+            echo "::warning::The Konflux pipeline may not have run yet or status was not posted."
+          elif [ "${STATE}" = "failure" ]; then
+            echo "::error::Konflux nightly test failed — see Details URL for pipeline run logs."
+          fi
+
+      - name: Summary
+        if: always()
+        env:
+          STATE: ${{ steps.nightly.outputs.state }}
+          DESCRIPTION: ${{ steps.nightly.outputs.description }}
+          TARGET_URL: ${{ steps.nightly.outputs.target_url }}
+        run: |
+          {
+            echo "## Feast Nightly Test Status"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Branch** | \`${{ steps.sha.outputs.branch }}\` |"
+            echo "| **Commit** | \`${{ steps.sha.outputs.sha }}\` |"
+            echo "| **Konflux status** | \`${STATE}\` |"
+            echo "| **Description** | ${DESCRIPTION} |"
+            if [ -n "${TARGET_URL}" ]; then
+              echo "| **Details** | [View pipeline run](${TARGET_URL}) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -1,0 +1,220 @@
+# Tekton Pipelines (Pipelines-as-Code)
+
+This directory contains Tekton `PipelineRun` definitions used for building and
+testing the Open Data Hub (ODH) Feast components on the Konflux ITS OpenShift
+environment. Pipelines are triggered by
+[Pipelines-as-Code](https://pipelinesascode.com/) based on repository events
+and comments.
+
+For Tekton concepts (Tasks, Pipelines, PipelineRuns), see the
+[Tekton Getting Started](http://tekton.dev/docs/getting-started/) documentation.
+
+---
+
+## Overview
+
+```
+PR opened / updated
+  ├─ odh-feast-operator-pull-request    → quay.io/opendatahub/feast-operator:odh-pr-<sha>
+  └─ odh-feature-server-pull-request   → quay.io/opendatahub/feature-server:odh-pr-<sha>
+        │
+        ├─ /group-test or group-test event  → feast-group-test   (tests PR images)
+        └─ /pr-e2etest comment              → feast-pr-test      (tests PR images)
+
+Merge to master
+  ├─ odh-feast-operator-push            → quay.io/opendatahub/feast-operator:odh-master
+  └─ odh-feature-server-push           → quay.io/opendatahub/feature-server:odh-master
+        │
+        └─ Daily 8 AM UTC cron /  → feast-nightly-test  (tests odh-master images)
+```
+
+All integration test pipelines provision an ephemeral HyperShift cluster
+(m5.2xlarge, latest OCP 4.x via EaaS), deploy the Feast operator and feature
+server, run the full test suite, collect must-gather artifacts, and post
+results back to GitHub.
+
+---
+
+## Build pipelines
+
+### `odh-feast-operator-pull-request.yaml` — Operator image build (PR)
+
+Builds the Feast operator image from a pull request and pushes it to quay.io.
+Required before running `/group-test` or `/pr-e2etest` on a PR.
+
+| | |
+|---|---|
+| **Trigger** | Pull request opened or updated targeting `master` |
+| **Source** | PR head branch at `{{revision}}` |
+| **Build context** | `infra/feast-operator` |
+| **Dockerfile** | `infra/feast-operator/Dockerfile` |
+| **Output image** | `quay.io/opendatahub/feast-operator:odh-pr-<sha>` and `odh-pr-<pr-number>` |
+| **Service account** | `build-pipeline-odh-feast-operator` |
+
+---
+
+### `odh-feature-server-pull-request.yaml` — Feature server image build (PR)
+
+Builds the feature server image from a pull request and pushes it to quay.io.
+Required before running `/group-test` or `/pr-e2etest` on a PR.
+
+| | |
+|---|---|
+| **Trigger** | Pull request opened or updated targeting `master` |
+| **Source** | PR head branch at `{{revision}}` |
+| **Build context** | `sdk/python/feast/infra/feature_servers/multicloud` |
+| **Dockerfile** | `sdk/python/feast/infra/feature_servers/multicloud/Dockerfile` |
+| **Output image** | `quay.io/opendatahub/feature-server:odh-pr-<sha>` and `odh-pr-<pr-number>` |
+| **Service account** | `build-pipeline-odh-feature-server` |
+
+---
+
+### `odh-feast-operator-push.yaml` — Operator image build (merge to master)
+
+Builds and pushes the Feast operator image on every merge to `master`. This is
+the image the nightly test pipeline resolves via the `odh-master` tag.
+
+| | |
+|---|---|
+| **Trigger** | Push to `master` |
+| **Source** | `master` branch |
+| **Build context** | `infra/feast-operator` |
+| **Dockerfile** | `infra/feast-operator/Dockerfile` |
+| **Output image** | `quay.io/opendatahub/feast-operator:odh-master` |
+| **Service account** | `build-pipeline-odh-feast-operator` |
+| **Pipeline** | [`multi-arch-container-build.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/pipeline/multi-arch-container-build.yaml) |
+
+---
+
+### `odh-feature-server-push.yaml` — Feature server image build (merge to master)
+
+Builds and pushes the feature server image on every merge to `master`. This is
+the image the nightly test pipeline resolves via the `odh-master` tag.
+
+| | |
+|---|---|
+| **Trigger** | Push to `master` |
+| **Source** | `master` branch |
+| **Build context** | `sdk/python/feast/infra/feature_servers/multicloud` |
+| **Dockerfile** | `sdk/python/feast/infra/feature_servers/multicloud/Dockerfile` |
+| **Output image** | `quay.io/opendatahub/feature-server:odh-master` |
+| **Service account** | `build-pipeline-odh-feature-server` |
+| **Pipeline** | [`multi-arch-container-build.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/pipeline/multi-arch-container-build.yaml) |
+
+---
+
+## Integration test pipelines
+
+All three test pipelines run the same test suite on an ephemeral HyperShift
+cluster. They differ only in what images they test and how they are triggered.
+
+**Tests that run:**
+
+| Test | Command | Description |
+|------|---------|-------------|
+| Feature Store Operator E2E | `make install && make deploy && make test-e2e` | Full operator + feature server e2e after deployment |
+| Registry REST API | `uv run pytest ...test_registry_rest_api.py --integration` | Integration tests for the registry REST API |
+| Previous-version compatibility | `make test-previous-version` | Validates compatibility with the previous operator version |
+| Upgrade test | `make test-upgrade` | Validates upgrading the operator to the tested version |
+
+After the test step, the pipeline runs must-gather (Feast + OpenShift),
+pushes artifacts to the CI artifacts repo and OCI storage, and posts
+results back to GitHub.
+
+The test runner image is defined in
+[`Dockerfile.go-its`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/integration-tests/feast/Dockerfile.go-its)
+and includes Go, Python, `oc`/kubectl, `uv`, `skopeo`, and other tools.
+
+---
+
+### `feast-nightly-test.yaml` — Nightly integration test
+
+Runs the full integration test suite against the latest `odh-master` images
+built by the push pipelines. Tests master branch quality on a daily cadence.
+
+| | |
+|---|---|
+| **Trigger** | Daily cron at **8 AM UTC** on `master` |
+| **Images tested** | `quay.io/opendatahub/feast-operator:odh-master` and `quay.io/opendatahub/feature-server:odh-master` — resolved by digest at run time |
+| **Source cloned** | `opendatahub-io/feast` at the commit embedded in the `odh-master` image label |
+| **Pipeline** | [`nightly-testing-pipeline.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/integration-tests/feast/nightly-testing-pipeline.yaml) |
+| **Result reporting** | Commit status `konflux/nightly-feast` posted to master HEAD; GitHub Actions monitors and opens issues on failure |
+
+**How images are resolved**
+
+The nightly pipeline does **not** build images inline. A `resolve-images` task
+runs `skopeo inspect` on the `odh-master` tags and reads the
+`io.openshift.build.commit.id` label to determine the exact source commit.
+This ensures tests always run against properly Konflux-built images (feast
+installed from PyPI, all assets present).
+
+---
+
+### `feast-group-test.yaml` — Group integration test
+
+Runs integration tests using images built from the **current pull request**.
+Use this when changes may affect both the Feast operator and the feature server
+(e.g. API changes, shared library updates).
+
+| | |
+|---|---|
+| **Trigger** | `group-test` event (from Konflux App Studio group-test workflow) |
+| **Trigger (manual)** | Comment `/group-test` on a pull request |
+| **Images tested** | PR-built images resolved by the `generate-snapshot` task (`odh-pr-<sha>`) |
+| **Source cloned** | `opendatahub-io/feast` at the PR commit |
+| **Pipeline** | [`pr-group-testing-pipeline.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/integration-tests/feast/pr-group-testing-pipeline.yaml) |
+| **Result reporting** | GitHub check run `Red Hat Konflux / feast-group-test` posted to the PR by Pipelines-as-Code; PR comment with artifact browser link posted on completion |
+
+**How images get into the group test**
+
+1. When a PR is opened or updated, `odh-feast-operator-pull-request` and
+   `odh-feature-server-pull-request` build and push images tagged
+   `odh-pr-<sha>` and `odh-pr-<pr-number>`.
+2. When `/group-test` is triggered, the `generate-snapshot` task finds those
+   PR images by component name, assembles a snapshot JSON with their digests
+   and git metadata, and passes it to `deploy-and-test`.
+
+Both the images and the source checkout use the same PR commit, so the code
+under test is always consistent.
+
+---
+
+### `feast-pr-test.yaml` — PR integration test (manual)
+
+Identical test flow to `feast-group-test` but triggered manually by a PR
+comment. Use this to run a full integration test on demand without waiting for
+the group-test event.
+
+| | |
+|---|---|
+| **Trigger (manual)** | Comment `/pr-e2etest` on a pull request |
+| **Images tested** | PR-built images resolved by the `generate-snapshot` task (`odh-pr-<sha>`) |
+| **Source cloned** | `opendatahub-io/feast` at the PR commit |
+| **Pipeline** | [`pr-group-testing-pipeline.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/integration-tests/feast/pr-group-testing-pipeline.yaml) |
+| **Max keep runs** | 5 (higher than group-test to retain more history for manual runs) |
+
+---
+
+## Trigger reference
+
+| Comment / event | Pipeline | Images tested | When to use |
+|-----------------|----------|---------------|-------------|
+| PR opened/updated | `odh-feast-operator-pull-request` + `odh-feature-server-pull-request` | — (build only) | Automatic on every PR |
+| `group-test` event or `/group-test` | `feast-group-test` | PR images | Multi-component changes |
+| `/pr-e2etest` | `feast-pr-test` | PR images | On-demand full e2e on a PR |
+| Daily 8 AM UTC `feast-nightly-test` | `odh-master` images | Master branch quality gate |
+| Merge to master | `odh-feast-operator-push` + `odh-feature-server-push` | — (build only) | Automatic on every merge |
+
+---
+
+## Pipeline definitions
+
+All integration test pipeline definitions live in
+[`opendatahub-io/odh-konflux-central`](https://github.com/opendatahub-io/odh-konflux-central/tree/main/integration-tests/feast):
+
+| File | Used by |
+|------|---------|
+| [`nightly-testing-pipeline.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/integration-tests/feast/nightly-testing-pipeline.yaml) | `feast-nightly-test` |
+| [`pr-group-testing-pipeline.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/integration-tests/feast/pr-group-testing-pipeline.yaml) | `feast-group-test`, `feast-pr-test` |
+| [`Dockerfile.go-its`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/integration-tests/feast/Dockerfile.go-its) | Test runner image for all test pipelines |
+| [`multi-arch-container-build.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/pipeline/multi-arch-container-build.yaml) | All build pipelines |

--- a/.tekton/feast-group-test.yaml
+++ b/.tekton/feast-group-test.yaml
@@ -1,0 +1,67 @@
+---
+# Feast Group Test Pipeline (Pipelines-as-Code)
+#
+# This PipelineRun triggers integration tests across multiple Feast components
+# (feast-operator and feature-server) in a single run. It is used for
+# group testing when changes may affect more than one component.
+#
+# Triggers:
+#   - Event: group-test (e.g. from Konflux/App Studio group-test workflow)
+#   - Comment: /group-test on a pull request
+#
+# Pipeline definition: odh-konflux-central/integration-tests/feast/pr-group-testing-pipeline.yaml
+# Components tested: odh-feast-operator-ci, odh-feature-server-ci
+#
+# Images used in the test are built from the PR by the per-component PR pipelines
+# (odh-feast-operator-pull-request, odh-feature-server-pull-request). generate-snapshot
+# assembles a snapshot of those PR-built image refs; deploy-and-test uses them and the
+# PR commit for e2e and REST API tests. See .tekton/README.md for details.
+#
+# Required template variables (supplied by Pipelines-as-Code):
+#   - revision, target_branch, pull_request_number, git_auth_secret
+#
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/feast?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "group-test"
+    pipelinesascode.tekton.dev/on-comment: "^/group-test"
+  name: feast-group-test
+  namespace: open-data-hub-tenant
+  labels:
+    appstudio.openshift.io/application: group-testing
+    appstudio.openshift.io/component: feast-group
+    pipelines.appstudio.openshift.io/type: test
+spec:
+  params:
+  - name: group-components
+    value: '{ "odh-feast-operator-ci": "opendatahub/feast-operator", "odh-feature-server-ci": "opendatahub/feature-server" }'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: integration-tests/feast/pr-group-testing-pipeline.yaml
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+      - effect: NoSchedule
+        key: konflux-ci.dev/workload
+        operator: Equal
+        value: konflux-tenants
+    serviceAccountName: konflux-integration-runner
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/feast-nightly-test.yaml
+++ b/.tekton/feast-nightly-test.yaml
@@ -1,0 +1,62 @@
+---
+# Feast Nightly Test Pipeline (Pipelines-as-Code)
+#
+# Triggers the nightly integration test pipeline which resolves the latest
+# Konflux-built odh-master images (pushed on every merge to master by the
+# odh-feast-operator-push and odh-feature-server-push pipelines), provisions
+# an ephemeral HyperShift cluster, deploys the operator and feature-server,
+# and runs the full e2e + REST API + previous-version + upgrade test suite.
+#
+# Triggers:
+#   - Cron: daily at 8 AM UTC
+#   - Comment: /nightly-test on a pull request
+#
+# Pipeline definition: odh-konflux-central/integration-tests/feast/nightly-testing-pipeline.yaml
+#
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/feast?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cron: "0 8 * * *"
+    pipelinesascode.tekton.dev/on-target-branch: "[master]"
+    pipelinesascode.tekton.dev/on-comment: "^/nightly-test"
+  name: feast-nightly-test
+  namespace: open-data-hub-tenant
+  labels:
+    appstudio.openshift.io/application: group-testing
+    appstudio.openshift.io/component: feast-nightly
+    pipelines.appstudio.openshift.io/type: test
+spec:
+  params:
+  - name: git-repo
+    value: opendatahub-io/feast
+  - name: git-branch
+    value: master
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: integration-tests/feast/nightly-testing-pipeline.yaml
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+      - effect: NoSchedule
+        key: konflux-ci.dev/workload
+        operator: Equal
+        value: konflux-tenants
+    serviceAccountName: konflux-integration-runner
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/feast-pr-test.yaml
+++ b/.tekton/feast-pr-test.yaml
@@ -1,0 +1,59 @@
+---
+# Feast PR integration test (Pipelines-as-Code)
+#
+# Runs the same Hypershift + deploy + e2e flow as /group-test: uses Konflux
+# snapshot images built from the pull request (odh-feast-operator-ci,
+# odh-feature-server-ci), not freshly built nightly images.
+#
+# Triggers:
+#   - Comment: /pr-e2etest on a pull request (manual trigger)
+#
+# Pipeline definition: opendatahub-io/odh-konflux-central
+#   integration-tests/feast/pr-group-testing-pipeline.yaml
+#
+# Components tested: odh-feast-operator-ci, odh-feature-server-ci
+#
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/feast?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+    pipelinesascode.tekton.dev/on-comment: "^/pr-e2etest"
+  name: feast-pr-test
+  namespace: open-data-hub-tenant
+  labels:
+    appstudio.openshift.io/application: group-testing
+    appstudio.openshift.io/component: feast-group
+    pipelines.appstudio.openshift.io/type: test
+spec:
+  params:
+  - name: group-components
+    value: '{ "odh-feast-operator-ci": "opendatahub/feast-operator", "odh-feature-server-ci": "opendatahub/feature-server" }'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: integration-tests/feast/pr-group-testing-pipeline.yaml
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+      - effect: NoSchedule
+        key: konflux-ci.dev/workload
+        operator: Equal
+        value: konflux-tenants
+    serviceAccountName: konflux-integration-runner
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/odh-feast-operator-pull-request.yaml
+++ b/.tekton/odh-feast-operator-pull-request.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/feast?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-feast-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-feast-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/feast-operator:odh-pr
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: infra/feast-operator
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+    - 'odh-pr-{{pull_request_number}}'
+  - name: pipeline-type
+    value: pull-request
+  - name: enable-group-testing
+    value: "true"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-feast-operator
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-feast-operator-push.yaml
+++ b/.tekton/odh-feast-operator-push.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/feast?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-feast-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-feast-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/feast-operator:odh-master
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: infra/feast-operator
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-feast-operator
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-feature-server-pull-request.yaml
+++ b/.tekton/odh-feature-server-pull-request.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/feast?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-feature-server-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-feature-server-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/feature-server:odh-pr
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: sdk/python/feast/infra/feature_servers/multicloud
+  - name: additional-tags
+    value: 
+    - 'odh-pr-{{revision}}'
+    - 'odh-pr-{{pull_request_number}}'
+  - name: pipeline-type
+    value: pull-request
+  - name: enable-group-testing
+    value: "true"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-feature-server
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-feature-server-push.yaml
+++ b/.tekton/odh-feature-server-push.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/feast?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-feature-server-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-feature-server-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/feature-server:odh-master
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: sdk/python/feast/infra/feature_servers/multicloud 
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-feature-server
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->
Adds the full Konflux ITS CI infrastructure for ODH Feast, enabling automated
image builds on every PR and merge, and nightly integration testing on
ephemeral HyperShift clusters.

## Build pipelines

| Pipeline | Trigger | Output image |
|----------|---------|--------------|
| `odh-feast-operator-pull-request` | PR → `master` | `quay.io/opendatahub/feast-operator:odh-pr-<sha>` |
| `odh-feature-server-pull-request` | PR → `master` | `quay.io/opendatahub/feature-server:odh-pr-<sha>` |
| `odh-feast-operator-push` | Merge to `master` | `quay.io/opendatahub/feast-operator:odh-master` |
| `odh-feature-server-push` | Merge to `master` | `quay.io/opendatahub/feature-server:odh-master` |

## Integration test pipelines

| Pipeline | Trigger | Images tested |
|----------|---------|---------------|
| `feast-nightly-test` | Daily 8 AM UTC + `/nightly-test` | `odh-master` (from push pipelines) |
| `feast-group-test` | `group-test` event + `/group-test` | PR snapshot (from PR build pipelines) |
| `feast-pr-test` | `/pr-e2etest` | PR snapshot (from PR build pipelines) |

Each test pipeline provisions an ephemeral HyperShift cluster (m5.2xlarge,
OCP 4.x via EaaS), deploys the Feast operator and feature server, and runs:

- Feature Store Operator E2E (`make test-e2e`)
- Registry REST API tests (`pytest ...test_registry_rest_api.py --integration`)
- Previous-version compatibility (`make test-previous-version`)
- Upgrade test (`make test-upgrade`)

## Nightly monitor

`trigger-konflux-nightly.yaml` — GitHub Actions workflow that runs at 11 AM
UTC, reads the `konflux/nightly-feast` commit status posted by the Konflux
pipeline, and reports the result in the Actions summary. 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated integration test pipelines for the Feast operator and feature-server (PR, push, group-test, and nightly runs).
  * Added a scheduled nightly monitoring workflow that checks Feast nightly test status, emits warnings/errors, and publishes a summarized report.
  * Enabled manual on-demand test triggers via PR comments and configured run retention/cancellation behavior.

* **Documentation**
  * Added comprehensive docs describing end-to-end integration test and build orchestration, image selection, and result reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->