### PR TITLE
Resolving checks issues while merging upstream in downstream

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1156,7 +1156,7 @@
         "filename": "infra/feast-operator/internal/controller/services/services.go",
         "hashed_secret": "36dc326eb15c7bdd8d91a6b87905bcea20b637d1",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 184
       }
     ],
     "infra/feast-operator/internal/controller/services/tls_test.go": [

--- a/infra/feast-operator/config/default/related_image_fs_patch.yaml
+++ b/infra/feast-operator/config/default/related_image_fs_patch.yaml
@@ -1,10 +1,16 @@
+- op: test
+  path: "/spec/template/spec/containers/0/env/1/name"
+  value: RELATED_IMAGE_FEATURE_SERVER
 - op: replace
-  path: "/spec/template/spec/containers/0/env/0"
+  path: "/spec/template/spec/containers/0/env/1"
   value:
     name: RELATED_IMAGE_FEATURE_SERVER
     value: quay.io/feastdev/feature-server:0.62.0
+- op: test
+  path: "/spec/template/spec/containers/0/env/2/name"
+  value: RELATED_IMAGE_CRON_JOB
 - op: replace
-  path: "/spec/template/spec/containers/0/env/1"
+  path: "/spec/template/spec/containers/0/env/2"
   value:
     name: RELATED_IMAGE_CRON_JOB
     value: quay.io/openshift/origin-cli:4.17

--- a/infra/feast-operator/go.mod
+++ b/infra/feast-operator/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.75.0
+	k8s.io/apiextensions-apiserver v0.30.2
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 )
 
@@ -26,6 +27,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -88,7 +90,6 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.30.2 // indirect
 	k8s.io/apiserver v0.30.2 // indirect
 	k8s.io/component-base v0.30.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect


### PR DESCRIPTION


# What this PR does / why we need it:
To fix Konflux build 

```
026-04-10 07:02:20,003 ERROR The command "/usr/local/go/go_latest/bin/go list -e -deps -json=ImportPath,Module,Standard,Deps all" failed
  2026-04-10 07:02:20,003 ERROR STDERR:
  go: downloading github.com/evanphx/json-patch v5.9.0+incompatible
  go: updates to go.mod needed; to update it:
  	go mod tidy
  2026-04-10 07:02:20,003 ERROR Failed to fetch gomod dependencies
  2026-04-10 07:02:20,982 ERROR PackageManagerError: Go execution failed: `/usr/local/go/go_latest/bin/go list -e -deps -json=ImportPath,Module,Standard,Deps all` failed with rc=1
  Error: PackageManagerError: Go execution failed: `/usr/local/go/go_latest/bin/go list -e -deps -json=ImportPath,Module,Standard,Deps all` failed with rc=1
```