### PR TITLE
fix: Remove selector with kustomize overlay using a JSON 6902 patch

### DIFF
--- a/infra/feast-operator/config/overlays/odh/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/odh/kustomization.yaml
@@ -11,6 +11,14 @@ resources:
 patches:
   # patch to remove default `system` namespace in ../../manager/manager.yaml
   - path: delete-namespace.yaml
+  # Remove app.kubernetes.io/name from the Deployment selector to avoid
+  # immutable spec.selector errors on upgrade. The label remains in the
+  # pod template so the metrics Service selector still targets only
+  # feast-operator pods.
+  - path: remove_selector_label_patch.yaml
+    target:
+      kind: Deployment
+      name: controller-manager
 
 configMapGenerator:
   - name:  feast-operator-parameters

--- a/infra/feast-operator/config/overlays/odh/remove_selector_label_patch.yaml
+++ b/infra/feast-operator/config/overlays/odh/remove_selector_label_patch.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/selector/matchLabels/app.kubernetes.io~1name

--- a/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
@@ -11,6 +11,14 @@ resources:
 patches:
   # patch to remove default `system` namespace in ../../manager/manager.yaml
   - path: delete-namespace.yaml
+  # Remove app.kubernetes.io/name from the Deployment selector to avoid
+  # immutable spec.selector errors on upgrade. The label remains in the
+  # pod template so the metrics Service selector still targets only
+  # feast-operator pods.
+  - path: remove_selector_label_patch.yaml
+    target:
+      kind: Deployment
+      name: controller-manager
 
 configMapGenerator:
   - name:  feast-operator-parameters

--- a/infra/feast-operator/config/overlays/rhoai/remove_selector_label_patch.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/remove_selector_label_patch.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/selector/matchLabels/app.kubernetes.io~1name


### PR DESCRIPTION

# What this PR does / why we need it:

https://redhat.atlassian.net/browse/RHOAIENG-58369 

With RHOAI/ODH DSC (DataScienceCluster): The DSC controller deploys the feast-operator using kustomize manifests (from config/overlays/rhoai/), not OLM. It applies the Deployment using a kubectl-like apply/patch operation against the existing Deployment on the cluster. This is where the immutable selector error occurs - it's trying to patch the running Deployment with new selector labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment configuration for feast-operator across multiple overlays to refine pod selector labels, ensuring consistent pod selection behavior during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->