### PR TITLE
fix: fix Konflux nightly cron trigger not scheduling automatically

### DIFF
--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -18,8 +18,8 @@ PR opened / updated
   ├─ odh-feast-operator-pull-request    → quay.io/opendatahub/feast-operator:odh-pr-<sha>
   └─ odh-feature-server-pull-request   → quay.io/opendatahub/feature-server:odh-pr-<sha>
         │
-        ├─ /group-test or group-test event  → feast-group-test   (tests PR images)
-        └─ /pr-e2etest comment              → feast-pr-test      (tests PR images)
+        ├─ /group-test or group-test event auto triggered  → feast-group-test   (tests PR images)
+        └─ /pr-e2etest comment for retest           → feast-pr-test      (tests PR images)
 
 Merge to master
   ├─ odh-feast-operator-push            → quay.io/opendatahub/feast-operator:odh-master
@@ -158,7 +158,7 @@ Use this when changes may affect both the Feast operator and the feature server
 
 | | |
 |---|---|
-| **Trigger** | `group-test` event (from Konflux App Studio group-test workflow) |
+| **Trigger** | Automatic — fires when both `odh-feast-operator-pull-request` and `odh-feature-server-pull-request` complete successfully on a PR.
 | **Trigger (manual)** | Comment `/group-test` on a pull request |
 | **Images tested** | PR-built images resolved by the `generate-snapshot` task (`odh-pr-<sha>`) |
 | **Source cloned** | `opendatahub-io/feast` at the PR commit |
@@ -170,8 +170,9 @@ Use this when changes may affect both the Feast operator and the feature server
 1. When a PR is opened or updated, `odh-feast-operator-pull-request` and
    `odh-feature-server-pull-request` build and push images tagged
    `odh-pr-<sha>` and `odh-pr-<pr-number>`.
-2. When `/group-test` is triggered, the `generate-snapshot` task finds those
-   PR images by component name, assembles a snapshot JSON with their digests
+2. Once both build pipelines succeed, `feast-group-test` is automatically
+   triggered. The `generate-snapshot` task finds those PR images by component
+   name, assembles a snapshot JSON with their digests
    and git metadata, and passes it to `deploy-and-test`.
 
 Both the images and the source checkout use the same PR commit, so the code

--- a/.tekton/feast-nightly-test.yaml
+++ b/.tekton/feast-nightly-test.yaml
@@ -9,7 +9,6 @@
 #
 # Triggers:
 #   - Cron: daily at 8 AM UTC
-#   - Comment: /nightly-test on a pull request
 #
 # Pipeline definition: odh-konflux-central/integration-tests/feast/nightly-testing-pipeline.yaml
 #
@@ -23,8 +22,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cron: "0 8 * * *"
-    pipelinesascode.tekton.dev/on-target-branch: "[master]"
-    pipelinesascode.tekton.dev/on-comment: "^/nightly-test"
+    pipelinesascode.tekton.dev/on-target-branch: "master"
   name: feast-nightly-test
   namespace: open-data-hub-tenant
   labels:


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->
The nightly test pipeline was never running automatically on schedule. Two annotation issues in .tekton/feast-nightly-test.yaml caused this:

- on-target-branch: "[master]" — the brackets confused PaC's cron scheduler. It couldn't resolve [master] as a real branch name, so the cron was never registered.

- on-comment: "^/nightly-test" mixed in the same file — PaC's cron registration conflicts when a comment trigger is present alongside on-cron.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [x] I've made sure the tests are passing.
- [ ] My commits are signed off (`git commit -s`)
- [ ] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the nightly test run trigger based on pull-request comments.
  * Updated nightly test targeting to use `master` for the branch selector.

* **Documentation**
  * Updated Tekton guidance/diagram for when `feast-group-test` starts: now automatically after both PR build pipelines succeed, and updated the snapshot-to-`deploy-and-test` flow description.

* **Tests**
  * Improved Ray offline-store e2e setup/teardown by ensuring the notebook ServiceAccount exists, applying Ray RBAC/NetworkPolicy, making Kueue setup best-effort, and strengthening cleanup.
  * Updated Kueue manifests to the `v1beta2` API version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->