### PR TITLE
fix: Replace selector label strip patch with migration Job for upgrade-safe selector uniqueness

### DIFF
--- a/infra/feast-operator/config/overlays/odh/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/odh/kustomization.yaml
@@ -6,19 +6,12 @@ namespace: opendatahub
 
 resources:
   - ../../default
+  - selector_migration_job.yaml
 
 
 patches:
   # patch to remove default `system` namespace in ../../manager/manager.yaml
   - path: delete-namespace.yaml
-  # Remove app.kubernetes.io/name from the Deployment selector to avoid
-  # immutable spec.selector errors on upgrade. The label remains in the
-  # pod template so the metrics Service selector still targets only
-  # feast-operator pods.
-  - path: remove_selector_label_patch.yaml
-    target:
-      kind: Deployment
-      name: controller-manager
 
 configMapGenerator:
   - name:  feast-operator-parameters
@@ -70,3 +63,13 @@ replacements:
           name: controller-manager
         fieldPaths:
           - spec.template.spec.containers.[name=manager].env.[name=OIDC_ISSUER_URL].value
+  - source:
+      kind: ConfigMap
+      name: feast-operator-parameters
+      fieldPath: data.RELATED_IMAGE_CRON_JOB
+    targets:
+      - select:
+          kind: Job
+          name: selector-migration
+        fieldPaths:
+          - spec.template.spec.containers.[name=migrate].image

--- a/infra/feast-operator/config/overlays/odh/remove_selector_label_patch.yaml
+++ b/infra/feast-operator/config/overlays/odh/remove_selector_label_patch.yaml
@@ -1,2 +1,0 @@
-- op: remove
-  path: /spec/selector/matchLabels/app.kubernetes.io~1name

--- a/infra/feast-operator/config/overlays/odh/selector_migration_job.yaml
+++ b/infra/feast-operator/config/overlays/odh/selector_migration_job.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: selector-migration
+  namespace: system
+  labels:
+    app.kubernetes.io/name: feast-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: feast-operator
+    spec:
+      serviceAccountName: controller-manager
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: migrate
+        image: origin-cli:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          DEPLOY="feast-operator-controller-manager"
+          NS="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+
+          HAS_LABEL=$(oc get deployment "$DEPLOY" -n "$NS" \
+            -o jsonpath='{.spec.selector.matchLabels.app\.kubernetes\.io/name}' 2>/dev/null || true)
+
+          if [ -z "$HAS_LABEL" ]; then
+            echo "Deployment $DEPLOY has old or missing selector."
+            echo "Deleting so it can be recreated with the correct selector..."
+            oc delete deployment "$DEPLOY" -n "$NS" --ignore-not-found=true
+            echo "Done. The operator will recreate the Deployment."
+          else
+            echo "Deployment selector is already correct, no migration needed."
+          fi

--- a/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
@@ -6,19 +6,12 @@ namespace: redhat-ods-applications
 
 resources:
   - ../../default
+  - selector_migration_job.yaml
 
 
 patches:
   # patch to remove default `system` namespace in ../../manager/manager.yaml
   - path: delete-namespace.yaml
-  # Remove app.kubernetes.io/name from the Deployment selector to avoid
-  # immutable spec.selector errors on upgrade. The label remains in the
-  # pod template so the metrics Service selector still targets only
-  # feast-operator pods.
-  - path: remove_selector_label_patch.yaml
-    target:
-      kind: Deployment
-      name: controller-manager
 
 configMapGenerator:
   - name:  feast-operator-parameters
@@ -70,3 +63,13 @@ replacements:
           name: controller-manager
         fieldPaths:
           - spec.template.spec.containers.[name=manager].env.[name=OIDC_ISSUER_URL].value
+  - source:
+      kind: ConfigMap
+      name: feast-operator-parameters
+      fieldPath: data.RELATED_IMAGE_CRON_JOB
+    targets:
+      - select:
+          kind: Job
+          name: selector-migration
+        fieldPaths:
+          - spec.template.spec.containers.[name=migrate].image

--- a/infra/feast-operator/config/overlays/rhoai/remove_selector_label_patch.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/remove_selector_label_patch.yaml
@@ -1,2 +1,0 @@
-- op: remove
-  path: /spec/selector/matchLabels/app.kubernetes.io~1name

--- a/infra/feast-operator/config/overlays/rhoai/selector_migration_job.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/selector_migration_job.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: selector-migration
+  namespace: system
+  labels:
+    app.kubernetes.io/name: feast-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: feast-operator
+    spec:
+      serviceAccountName: controller-manager
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: migrate
+        image: origin-cli:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          DEPLOY="feast-operator-controller-manager"
+          NS="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+
+          HAS_LABEL=$(oc get deployment "$DEPLOY" -n "$NS" \
+            -o jsonpath='{.spec.selector.matchLabels.app\.kubernetes\.io/name}' 2>/dev/null || true)
+
+          if [ -z "$HAS_LABEL" ]; then
+            echo "Deployment $DEPLOY has old or missing selector."
+            echo "Deleting so it can be recreated with the correct selector..."
+            oc delete deployment "$DEPLOY" -n "$NS" --ignore-not-found=true
+            echo "Done. The operator will recreate the Deployment."
+          else
+            echo "Deployment selector is already correct, no migration needed."
+          fi


### PR DESCRIPTION

Fixes: [RHOAIENG-58369](https://issues.redhat.com/browse/RHOAIENG-58369) and https://redhat.atlassian.net/browse/RHOAIENG-62641 



# What this PR does / why we need it:

## Summary

- Replaces the `remove_selector_label_patch.yaml` workaround (which stripped `app.kubernetes.io/name` from the Deployment selector) with a pre-upgrade migration Job that deletes the existing `feast-operator-controller-manager` Deployment if its `spec.selector` doesn't match the expected labels
- Preserves upstream's `app.kubernetes.io/name: feast-operator` label in the Deployment selector for label uniqueness, while ensuring clean upgrades from all prior RHOAI/ODH versions (3.0 through 3.5-ea.1)

## Problem

Upgrading from any prior RHOAI release to 3.5-ea.1 fails because `spec.selector.matchLabels` is an immutable field in Kubernetes:
`Deployment.apps "feast-operator-controller-manager" is invalid: spec.selector: Invalid value: ...: field is immutable`

## Solution

A `selector-migration` Job (in both RHOAI and ODH overlays) that:
1. Runs using the existing `ose-cli` image (`RELATED_IMAGE_CRON_JOB` from `params.env`)
2. Uses the existing `controller-manager` ServiceAccount (already has Deployment `get`/`delete` RBAC)
3. Checks the existing Deployment's `spec.selector.matchLabels` for `app.kubernetes.io/name`
4. If missing (old selector) → deletes the Deployment so the operator can recreate it with the correct 2-label selector
5. If present → no-op, exits cleanly
6. Auto-cleans up after 300 seconds via `ttlSecondsAfterFinished`





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a migration job that automatically handles deployment selector configuration updates.

* **Configuration Updates**
  * Updated deployment overlay configurations to include the migration capability.
  * Streamlined patch configuration by removing the previous selector label adjustment.
  * Added image replacement mapping for the migration job component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->