### PR TITLE
test: Add Post Upgrade Scenarios registry data and materialization validation

### DIFF
--- a/infra/feast-operator/test/e2e_rhoai/feast_postupgrade_test.go
+++ b/infra/feast-operator/test/e2e_rhoai/feast_postupgrade_test.go
@@ -38,14 +38,31 @@ var _ = Describe("Feast PostUpgrade scenario Testing", Ordered, func() {
 		fmt.Printf("Namespace %s deleted successfully\n", namespace)
 	})
 	runPostUpgradeTest := func() {
+
+		By("Checking if the Feast deployment is available after upgrade")
+		CheckDeployment(namespace, feastDeploymentName)
+
 		By("Verify Feature Store CR is in Ready state")
 		ValidateFeatureStoreCRStatus(namespace, feastCRName)
+
+		By("Validating feature_store.yaml contains S3 registry path and driver_ranking project")
+		ValidateFeatureStoreYamlS3(namespace, feastDeploymentName)
+
+		By("Validating pre-upgrade registry objects are intact in S3 (before feast apply)")
+		ValidateRegistryIntact(namespace, feastDeploymentName, testDir)
+
+		By("Validating materialization intervals (last_updated_timestamp) are preserved post-upgrade")
+		ValidateMaterializationIntervals(namespace, feastDeploymentName, testDir)
 
 		By("Running `feast apply` and `feast materialize-incremental` to validate registry definitions (S3 / driver_ranking)")
 		VerifyApplyFeatureStoreDefinitionsS3(namespace, feastCRName, feastDeploymentName)
 
 		By("Validating Feast project list for driver_ranking")
 		VerifyFeastMethodsForDriverRanking(namespace, feastDeploymentName, testDir)
+
+		By("Verifying online feature serving is queryable post-upgrade and post-materialization")
+		VerifyOnlineFeatureServing(namespace, feastDeploymentName, testDir)
+
 	}
 
 	// This context verifies that a pre-created Feast FeatureStore CR continues to function as expected

--- a/infra/feast-operator/test/e2e_rhoai/utils/util.go
+++ b/infra/feast-operator/test/e2e_rhoai/utils/util.go
@@ -532,18 +532,6 @@ func VerifyFeastMethods(namespace string, feastDeploymentName string, testDir st
 	}
 }
 
-// VerifyFeastMethodsForDriverRanking checks CLI output for the driver_ranking project (S3 registry).
-func VerifyFeastMethodsForDriverRanking(namespace string, feastDeploymentName string, testDir string) {
-	cmd := exec.Command("kubectl", "exec", "deploy/"+feastDeploymentName, "-n", namespace, "-c", "online", "--",
-		"feast", "projects", "list")
-	output, err := testutils.Run(cmd, testDir)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	fmt.Printf("Command: feast projects list\nOutput:\n%s\n", string(output))
-	VerifyOutputContains(output, []string{"driver_ranking"})
-	fmt.Printf("Assertion OK: output contains expected substring driver_ranking\n")
-}
-
 // ReplaceNamespaceInYaml reads a YAML file, replaces all existingNamespace with the actual namespace
 func ReplaceNamespaceInYamlFilesInPlace(filePaths []string, existingNamespace string, actualNamespace string) error {
 	for _, filePath := range filePaths {
@@ -567,4 +555,183 @@ func VerifyOutputContains(output []byte, expectedSubstrings []string) {
 	for _, expected := range expectedSubstrings {
 		Expect(outputStr).To(ContainSubstring(expected), fmt.Sprintf("Expected output to contain: %s", expected))
 	}
+}
+
+func ValidateFeatureStoreYamlS3(namespace, deployment string) {
+	cmd := exec.Command("kubectl", "exec", "deploy/"+deployment, "-n", namespace, "-c", "online", "--", "cat", "feature_store.yaml")
+	output, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "Failed to read feature_store.yaml")
+
+	content := string(output)
+	Expect(content).To(ContainSubstring("project: driver_ranking"))
+	Expect(content).To(ContainSubstring("s3://"))
+	fmt.Printf("feature_store.yaml in online pod: contains project driver_ranking and s3:// registry path\n")
+}
+
+// ValidateMaterializationIntervals verifies that two properties survived the operator upgrade:
+//
+//  1. The K8s CronJob that drives feast materialize-incremental still has a non-empty
+//     schedule — a schedule wipe would silently stop all future materialization.
+//
+//  2. The per-feature-view materialization bookmark (materializationIntervals in the S3 registry)
+//     is intact. feast materialize-incremental uses the most recent interval endTime as its
+//     start window; if the bookmark is wiped, the next run re-materializes from epoch (full scan).
+//     If the bookmark was never written pre-upgrade (CronJob had not yet fired), the
+//     materializationIntervals list is empty and this check is skipped with a warning.
+func ValidateMaterializationIntervals(namespace string, feastDeploymentName string, testDir string) {
+	By("Asserting CronJob schedule was not wiped by the upgrade")
+	cmd := exec.Command("kubectl", "get", "cronjob", feastDeploymentName,
+		"-n", namespace, "-o", "jsonpath={.spec.schedule}")
+	output, err := testutils.Run(cmd, testDir)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+		fmt.Sprintf("CronJob %s not found in namespace %s — upgrade may have deleted it", feastDeploymentName, namespace))
+	schedule := strings.TrimSpace(string(output))
+	ExpectWithOffset(1, schedule).NotTo(BeEmpty(),
+		"CronJob schedule is empty — upgrade reset the materialization schedule")
+	fmt.Printf("CronJob %s schedule: %q (preserved)\n", feastDeploymentName, schedule)
+
+	for _, fv := range []string{"driver_hourly_stats", "driver_hourly_stats_fresh"} {
+		By(fmt.Sprintf("Asserting materialization bookmark for feature view %s", fv))
+		cmd = exec.Command(
+			"kubectl", "exec", "deploy/"+feastDeploymentName,
+			"-n", namespace, "-c", "online", "--",
+			"feast", "feature-views", "describe", fv,
+		)
+		output, err = testutils.Run(cmd, testDir)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+			fmt.Sprintf("feast feature-views describe %s failed — S3 registry may be inaccessible", fv))
+
+		described := string(output)
+		fmt.Printf("feast feature-views describe %s:\n%s\n", fv, described)
+
+		ExpectWithOffset(1, described).To(ContainSubstring("materializationIntervals"),
+			fmt.Sprintf("feature view %s: materializationIntervals field missing — "+
+				"registry entry may have been reset by the upgrade", fv))
+
+		if strings.Contains(described, "startTime") {
+			ExpectWithOffset(1, described).NotTo(ContainSubstring("1970-01-01"),
+				fmt.Sprintf("feature view %s: materializationIntervals contain epoch timestamp (1970-01-01) — "+
+					"bookmark was reset by the upgrade; next incremental job will re-materialize from epoch", fv))
+			fmt.Printf("Feature view %s: materialization bookmark intact (non-epoch startTime present)\n", fv)
+		} else {
+			fmt.Printf("NOTICE: feature view %s has no materializationIntervals — "+
+				"CronJob may not have fired before the upgrade; bookmark check skipped\n", fv)
+		}
+	}
+}
+
+func ValidateRegistryIntact(namespace string, feastDeploymentName string, testDir string) {
+	type feastCheck struct {
+		command   []string
+		expected  []string
+		logPrefix string
+	}
+
+	checks := []feastCheck{
+		{
+			command:   []string{"feast", "projects", "list"},
+			expected:  []string{"driver_ranking"},
+			logPrefix: "Projects List",
+		},
+		{
+			command:   []string{"feast", "feature-views", "list"},
+			expected:  []string{"driver_hourly_stats", "driver_hourly_stats_fresh", "transformed_conv_rate", "transformed_conv_rate_fresh"},
+			logPrefix: "Feature Views List",
+		},
+		{
+			command:   []string{"feast", "entities", "list"},
+			expected:  []string{"driver"},
+			logPrefix: "Entities List",
+		},
+		{
+			command:   []string{"feast", "data-sources", "list"},
+			expected:  []string{"driver_hourly_stats_source", "vals_to_add", "driver_stats_push_source"},
+			logPrefix: "Data Sources List",
+		},
+		{
+			command: []string{"feast", "features", "list"},
+			expected: []string{
+				"conv_rate", "acc_rate", "avg_daily_trips",
+				"driver_metadata", "driver_config", "driver_profile",
+				"conv_rate_plus_val1", "conv_rate_plus_val2",
+			},
+			logPrefix: "Features List",
+		},
+		{
+			command:   []string{"feast", "feature-services", "list"},
+			expected:  []string{"driver_activity_v1", "driver_activity_v2"},
+			logPrefix: "Feature Services List",
+		},
+	}
+
+	for _, check := range checks {
+		cmd := exec.Command("kubectl", "exec", "deploy/"+feastDeploymentName, "-n", namespace, "-c", "online", "--")
+		cmd.Args = append(cmd.Args, check.command...)
+		output, err := testutils.Run(cmd, testDir)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+			fmt.Sprintf("feast %s list failed — registry may be inaccessible or objects wiped by upgrade", check.logPrefix))
+
+		fmt.Printf("%s:\n%s\n", check.logPrefix, string(output))
+		for _, expected := range check.expected {
+			ExpectWithOffset(1, string(output)).To(ContainSubstring(expected),
+				fmt.Sprintf("registry intact check: %s list missing %q — was the S3 registry wiped by the upgrade?", check.logPrefix, expected))
+		}
+	}
+	fmt.Printf("Registry intact: all pre-upgrade objects present in S3 registry\n")
+}
+
+// VerifyFeastMethodsForDriverRanking confirms the driver_ranking project is listed post-apply.
+// Unlike ValidateRegistryIntact it runs after feast apply and serves as a write-path smoke test.
+func VerifyFeastMethodsForDriverRanking(namespace string, feastDeploymentName string, testDir string) {
+	cmd := exec.Command("kubectl", "exec", "deploy/"+feastDeploymentName, "-n", namespace, "-c", "online", "--",
+		"feast", "projects", "list")
+	output, err := testutils.Run(cmd, testDir)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	fmt.Printf("Command: feast projects list\nOutput:\n%s\n", string(output))
+	VerifyOutputContains(output, []string{"driver_ranking"})
+	fmt.Printf("Assertion OK: output contains expected substring driver_ranking\n")
+}
+
+func VerifyOnlineFeatureServing(namespace string, feastDeploymentName string, testDir string) {
+	var output []byte
+	var err error
+
+	// Retry up to 3 times — the online store may take a moment to become ready
+	// after the deployment rolls out during an upgrade.
+	for attempt := 1; attempt <= 3; attempt++ {
+		cmd := exec.Command(
+			"kubectl", "exec", "deploy/"+feastDeploymentName,
+			"-n", namespace, "-c", "online", "--",
+			"feast", "get-online-features",
+			"-e", "driver_id=1001",
+			"-e", "driver_id=1002",
+			"-f", "driver_hourly_stats:conv_rate",
+			"-f", "driver_hourly_stats:acc_rate",
+			"-f", "driver_hourly_stats:avg_daily_trips",
+		)
+		output, err = testutils.Run(cmd, testDir)
+		if err == nil {
+			break
+		}
+		if attempt < 3 {
+			fmt.Printf("feast get-online-features attempt %d/3 failed: %v — retrying\n", attempt, err)
+			cmd2 := exec.Command("sleep", "5")
+			_, _ = testutils.Run(cmd2, testDir)
+		}
+	}
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+		fmt.Sprintf("feast get-online-features failed after 3 attempts — "+
+			"online store may be inaccessible post-upgrade:\n%s", string(output)))
+
+	response := string(output)
+	fmt.Printf("feast get-online-features response:\n%s\n", response)
+
+	for _, feature := range []string{"conv_rate", "acc_rate", "avg_daily_trips", "driver_id"} {
+		ExpectWithOffset(1, response).To(ContainSubstring(feature),
+			fmt.Sprintf("%q missing from get-online-features output — "+
+				"online store schema may have changed or materialization did not write data", feature))
+	}
+
+	fmt.Printf("VerifyOnlineFeatureServing: online feature serving verified via feast get-online-features\n")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->
Add Post-Upgrade Scenarios: Registry Data and Materialization Validation

This PR extends the RHOAI post-upgrade E2E test suite (feast_postupgrade_test.go) with additional validation steps to ensure Feast continues to function correctly after an operator upgrade. The new checks run before feast apply to verify that the upgrade did not corrupt or wipe pre-existing registry state.

Added steps to validate runPostUpgradeTest:

- Deployment availability check — confirms the Feast deployment is up before any registry access.
- ValidateFeatureStoreYamlS3 — asserts that feature_store.yaml in the online container still references the driver_ranking project and an s3:// registry path.
- ValidateRegistryIntact (pre-apply) — exhaustively checks that all pre-upgrade objects (project, feature views, entities, data sources, features, feature services) are still present in the S3 registry before any writes.
- ValidateMaterializationIntervals (pre-apply) — asserts the K8s CronJob schedule was not wiped and that per-feature-view materialization bookmarks (materializationIntervals) survived the upgrade without being reset to epoch.
- VerifyOnlineFeatureServing (post-materialization) — queries feast get-online-features for driver_id=1001/1002 with retry logic to confirm the online store is queryable end-to-end.
- Deployment availability check 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [ ] I've made sure the tests are passing.
- [ ] My commits are signed off (`git commit -s`)
- [ ] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end post-upgrade validation to confirm Feature Store readiness, verify expected S3 registry contents, ensure pre-upgrade registry objects remain intact, and preserve materialization interval timestamps.
  * Added stronger upgrade verification for incremental materialization and online feature serving, including retries and additional assertions that required feature/entity fields remain queryable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->