### PR TITLE
fix: Remove --label flags from sync workflows to avoid label-not-found errors

### DIFF
--- a/.github/workflows/sync_downstream_branch.yml
+++ b/.github/workflows/sync_downstream_branch.yml
@@ -139,9 +139,7 @@ jobs:
           git add .
           git cherry-pick --continue
           git push origin ${BRANCH} --force
-          \`\`\`" \
-              --label "sync-to-${VERSION}" \
-              --label "needs-manual-resolution")
+          \`\`\`")
           else
             PR_URL=$(gh pr create \
               --repo "$DOWNSTREAM_REPO" \
@@ -152,8 +150,7 @@ jobs:
 
           Cherry-pick of ${SOURCE_PR_URL} to \`${TARGET_BRANCH}\`.
 
-          This PR was automatically created and will auto-merge after CI passes." \
-              --label "sync-to-${VERSION}")
+          This PR was automatically created and will auto-merge after CI passes.")
           fi
 
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync_stable_branch.yml
+++ b/.github/workflows/sync_stable_branch.yml
@@ -80,9 +80,7 @@ jobs:
           git add .
           git cherry-pick --continue
           git push origin auto-sync/stable/${PR_NUMBER} --force
-          \`\`\`" \
-              --label "sync-to-stable" \
-              --label "needs-manual-resolution")
+          \`\`\`")
           else
             PR_URL=$(gh pr create \
               --base stable \
@@ -92,8 +90,7 @@ jobs:
 
           Cherry-pick of ${SOURCE_PR_URL} to \`stable\` branch.
 
-          This PR was automatically created and will auto-merge after CI passes." \
-              --label "sync-to-stable")
+          This PR was automatically created and will auto-merge after CI passes.")
           fi
 
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync_upstream.yml
+++ b/.github/workflows/sync_upstream.yml
@@ -88,9 +88,7 @@ jobs:
           git add .
           git cherry-pick --continue
           git push origin ${BRANCH} --force
-          \`\`\`" \
-              --label "sync-to-upstream" \
-              --label "needs-manual-resolution")
+          \`\`\`")
           else
             PR_URL=$(gh pr create \
               --repo "$UPSTREAM_REPO" \
@@ -101,8 +99,7 @@ jobs:
 
           Cherry-pick of ${SOURCE_PR_URL} to upstream \`master\` branch.
 
-          This PR was automatically created from the midstream repository." \
-              --label "sync-to-upstream")
+          This PR was automatically created from the midstream repository.")
           fi
 
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Removed `--label` flags from `gh pr create` commands in all three sync workflows (`sync_upstream.yml`, `sync_stable_branch.yml`, `sync_downstream_branch.yml`)
- These labels (`sync-to-upstream`, `sync-to-stable`, `sync-to-${VERSION}`, `needs-manual-resolution`) don't exist on target repositories (`feast-dev/feast`, `red-hat-data-services/feast`), causing the sync to fail with "label not found in stream"
- The PR titles already encode the sync context (e.g., `sync(upstream):`, `sync(stable):`, `sync(rhoai-3.5):`), making the labels redundant

## Test plan
- [x] Verify YAML validity of all modified workflow files
- [ ] Merge and confirm the next sync PR creation succeeds without label errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automated pull request creation across branch synchronization workflows.
  * Corrected pull request descriptions so Markdown formatting and command metadata are properly terminated.
  * Added clearer notices explaining when pull requests are created automatically and will merge after CI passes.
  * Improved conflict-related pull request details to support clearer manual resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->