### PR TITLE
fix: Handle rebase-and-merge PRs in sync workflows

### DIFF
--- a/.github/workflows/sync_downstream_branch.yml
+++ b/.github/workflows/sync_downstream_branch.yml
@@ -99,7 +99,15 @@ jobs:
 
           git checkout -b "$BRANCH" "downstream/${TARGET_BRANCH}"
 
-          if git cherry-pick -m 1 "$MERGE_SHA"; then
+          PARENT_COUNT=$(git cat-file -p "$MERGE_SHA" | grep -c "^parent")
+          if [ "$PARENT_COUNT" -gt 1 ]; then
+            CHERRY_PICK_CMD="git cherry-pick -m 1 $MERGE_SHA"
+          else
+            COMMIT_COUNT=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits | length')
+            CHERRY_PICK_CMD="git cherry-pick ${MERGE_SHA}~$((COMMIT_COUNT - 1))^..${MERGE_SHA}"
+          fi
+
+          if eval "$CHERRY_PICK_CMD"; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
           else
             git cherry-pick --abort || true

--- a/.github/workflows/sync_stable_branch.yml
+++ b/.github/workflows/sync_stable_branch.yml
@@ -42,8 +42,15 @@ jobs:
 
           git checkout -b "$BRANCH" origin/stable
 
-          # -m 1 handles merge commits by picking the first parent
-          if git cherry-pick -m 1 "$MERGE_SHA"; then
+          PARENT_COUNT=$(git cat-file -p "$MERGE_SHA" | grep -c "^parent")
+          if [ "$PARENT_COUNT" -gt 1 ]; then
+            CHERRY_PICK_CMD="git cherry-pick -m 1 $MERGE_SHA"
+          else
+            COMMIT_COUNT=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits | length')
+            CHERRY_PICK_CMD="git cherry-pick ${MERGE_SHA}~$((COMMIT_COUNT - 1))^..${MERGE_SHA}"
+          fi
+
+          if eval "$CHERRY_PICK_CMD"; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
           else
             git cherry-pick --abort || true

--- a/.github/workflows/sync_upstream.yml
+++ b/.github/workflows/sync_upstream.yml
@@ -49,7 +49,15 @@ jobs:
 
           git checkout -b "$BRANCH" upstream/master
 
-          if git cherry-pick -m 1 "$MERGE_SHA"; then
+          PARENT_COUNT=$(git cat-file -p "$MERGE_SHA" | grep -c "^parent")
+          if [ "$PARENT_COUNT" -gt 1 ]; then
+            CHERRY_PICK_CMD="git cherry-pick -m 1 $MERGE_SHA"
+          else
+            COMMIT_COUNT=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits | length')
+            CHERRY_PICK_CMD="git cherry-pick ${MERGE_SHA}~$((COMMIT_COUNT - 1))^..${MERGE_SHA}"
+          fi
+
+          if eval "$CHERRY_PICK_CMD"; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
           else
             git cherry-pick --abort || true


### PR DESCRIPTION
## Summary
- `cherry-pick -m 1` only works for true merge commits. When PRs are merged with "Rebase and merge", `merge_commit_sha` points to a regular commit and `-m 1` causes git to error out, resulting in empty cherry-picks with "cherry-pick of #N failed — manual resolution needed"
- All three sync workflows now detect whether `MERGE_SHA` is a merge commit (multiple parents) or a regular commit, and use the appropriate strategy:
  - **Merge commit**: `cherry-pick -m 1` (existing behavior)
  - **Regular commit (squash/rebase)**: get the PR's commit count via `gh pr view` and cherry-pick the full commit range

## Test plan
- [x] YAML validated for all three workflow files
- [ ] Merge a PR with "Rebase and merge" strategy with sync labels and verify the sync workflow correctly cherry-picks all commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated branch synchronization to correctly cherry-pick both merge commits and standard pull request commits.
  * Reduced unnecessary cherry-pick conflicts during upstream, downstream, and stable branch synchronization.
  * Preserved existing conflict handling and manual-resolution signaling when synchronization cannot be completed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->